### PR TITLE
SRC Crafting Data update

### DIFF
--- a/data.json
+++ b/data.json
@@ -24,9 +24,10 @@
         "Xhalium": 1000000000,
         "Ymrium": 33000
     },
-    "objects": [{
+    "objects": [
+        {
             "Name": "Block of 4 Ore Crates",
-            "CraftingTime": 60,
+            "CraftingTime": 60.0,
             "Materials": {
                 "Bastium": 2321.71,
                 "Vokarium": 542.34
@@ -38,11 +39,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Basic Crafting Bench",
-            "CraftingTime": 300,
+            "CraftingTime": 300.0,
             "Materials": {
                 "Ajatite": 1987.02,
                 "Bastium": 3974.04,
@@ -56,11 +57,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "T1 Thruster Box",
-            "CraftingTime": 60,
+            "CraftingTime": 60.0,
             "Materials": {
                 "Bastium": 780.24,
                 "Charodium": 1150.96,
@@ -73,13 +74,13 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "T1 Thruster Triangle",
-            "CraftingTime": 30,
+            "CraftingTime": 30.0,
             "Materials": {
-                "Bastium": 379,
+                "Bastium": 379.0,
                 "Charodium": 510.74,
                 "Vokarium": 184.49
             },
@@ -90,11 +91,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Main Flight Computer",
-            "CraftingTime": 15,
+            "CraftingTime": 15.0,
             "Materials": {
                 "Ajatite": 77.58,
                 "Bastium": 77.58,
@@ -106,11 +107,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Extention Corner 3 Ore Crate",
-            "CraftingTime": 40,
+            "CraftingTime": 40.0,
             "Materials": {
                 "Bastium": 1276.22,
                 "Vokarium": 298.81
@@ -122,11 +123,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Box Thruster Body Tier 1",
-            "CraftingTime": 10,
+            "CraftingTime": 10.0,
             "Materials": {
                 "Bastium": 307.51,
                 "Charodium": 439.3,
@@ -138,11 +139,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 1198.35
         },
         {
             "Name": "Resource Bridge",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 15.48,
                 "Bastium": 61.92,
@@ -154,11 +155,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Flight Control Unit Basic",
-            "CraftingTime": 6,
+            "CraftingTime": 6.0,
             "Materials": {
                 "Ajatite": 129.15,
                 "Bastium": 129.15,
@@ -170,11 +171,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 325.45
         },
         {
             "Name": "Basic 1 Ore Crate (Corner)",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 650.26,
                 "Vokarium": 170.12
@@ -186,43 +187,43 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Curved 1 Ore Crate",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 615.15,
                 "Vokarium": 140.06
             },
             "Research": {
-               "Cube": 40,
-               "Power": 8,
-               "Gear": 8
+                "Cube": 40,
+                "Power": 8,
+                "Gear": 8
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "L-Shape 1 Ore Crate",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 627.73,
                 "Vokarium": 140.06
             },
             "Research": {
-               "Cube": 36,
-               "Power": 8,
-               "Gear": 8
+                "Cube": 36,
+                "Power": 8,
+                "Gear": 8
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Basic",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 265.8,
                 "Vokarium": 64.03
@@ -232,11 +233,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Basic 1 Hardpoint",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 66.42,
                 "Bastium": 278.07,
@@ -247,11 +248,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "L-Shape 1 Hardpoint",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 66.42,
                 "Bastium": 434.81,
@@ -262,11 +263,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "L-Shape 2 Hardpoint",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 132.84,
                 "Bastium": 415.96,
@@ -277,11 +278,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "L-Shape Basic",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 451.25,
                 "Vokarium": 63.22
@@ -291,11 +292,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "L-Shape Basic Corner",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 586.05,
                 "Vokarium": 58.19
@@ -305,11 +306,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Curved Basic",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 404.02,
                 "Vokarium": 66.75
@@ -319,11 +320,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Curved Corner 2 Hardpoint",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 132.33,
                 "Bastium": 646.78,
@@ -334,11 +335,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Extention (3 Connection)",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 502.13,
                 "Vokarium": 126.58
@@ -348,11 +349,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Extention 2 Hardpoint (3 Connection)",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 132.84,
                 "Bastium": 540.6,
@@ -363,11 +364,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Extention 3 Hardpoint (3 Connection)",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 199.26,
                 "Bastium": 568.77,
@@ -378,11 +379,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Extention 4 Hardpoint (2 Connection)",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 265.68,
                 "Bastium": 666.51,
@@ -393,11 +394,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Extention 5 Hardpoint (1 Connection)",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 332.11,
                 "Bastium": 788.59,
@@ -408,11 +409,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Extention Hatch",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 11.43,
                 "Bastium": 256.82,
@@ -424,11 +425,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Curved L-Shape Adapter",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 424.66,
                 "Vokarium": 63.22
@@ -438,11 +439,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Inner Corner",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 305.33,
                 "Vokarium": 90.2
@@ -452,11 +453,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Bottleneck 1",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 347.04,
                 "Vokarium": 130.36
@@ -466,11 +467,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Bottleneck 2",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 658.37,
                 "Vokarium": 149.79
@@ -480,11 +481,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Bottleneck 4 Curved",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 1057.13,
                 "Vokarium": 244.26
@@ -494,11 +495,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Bottleneck 4",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 1008.33,
                 "Vokarium": 244.26
@@ -508,11 +509,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Extention Wing 5 Hardpoint (1 Connection)",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 45.08,
                 "Bastium": 505.41,
@@ -523,11 +524,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Modular Ore Cargo Crate",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 398.41,
                 "Vokarium": 99.6
@@ -539,11 +540,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Pilot Chair",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 64.7,
                 "Vokarium": 34.84
@@ -554,11 +555,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Bolt Tool Magazine",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 20.84
             },
@@ -567,11 +568,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Cockpit 2 Small Exposed (T1 Laborer)",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 740.6,
                 "Bastium": 2003.61,
@@ -586,11 +587,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Cockpit 2 Small Exposed",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 646.99,
                 "Bastium": 1788.34,
@@ -605,30 +606,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
-        },
-        {
-            "Name": "Cockpit 2 Small Exposed",
-            "CraftingTime": 0,
-            "Materials": {
-                "Ajatite": 646.99,
-                "Bastium": 1788.34,
-                "Charodium": 581.25,
-                "Nhurgite": 1362.95,
-                "Vokarium": 3668.97
-            },
-            "Research": {
-                "Cube": 136,
-                "Power": 483,
-                "Gear": 30
-            },
-            "Favourite": 0,
-            "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Cockpit 3 Small",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Aegisium": 1418.33,
                 "Ajatite": 3561.56,
@@ -643,11 +625,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Top Cockpit Exposed 1x2 Long",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 651.34,
                 "Bastium": 1476.53,
@@ -662,11 +644,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Cockpit 3 Medium Exposed",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 852.97,
                 "Bastium": 2912.32,
@@ -681,11 +663,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Top Cockpit Exposed 1x2 Wide",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 659.66,
                 "Bastium": 1565.07,
@@ -700,11 +682,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Assault Rifle Magazine",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 7.56,
                 "Ice": 18.96,
@@ -715,14 +697,14 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Power Pack",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 0.72,
-                "Nhurgite": 800
+                "Nhurgite": 800.0
             },
             "Research": {
                 "Power": 7,
@@ -730,14 +712,14 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Tools & Weapons Crafting Bench",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 2392.79,
-                "Bastium": 1595.20,
+                "Bastium": 1595.2,
                 "Charodium": 8773.58,
                 "Vokarium": 3190.39
             },
@@ -749,15 +731,15 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Pipe Tool",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
-                "Ajatite": 1072.50,
-                "Bastium": 1073,
-                "Vokarium": 536
+                "Ajatite": 1072.5,
+                "Bastium": 1073.0,
+                "Vokarium": 536.0
             },
             "Research": {
                 "Cube": 1,
@@ -766,14 +748,14 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Bolt Tool",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 682.5,
-                "Bastium": 1594,
+                "Bastium": 1594.0,
                 "Vokarium": 2276.5
             },
             "Research": {
@@ -783,11 +765,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Small Fuel Rod Rack",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 172.05
             },
@@ -796,11 +778,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Tier 1 Generator Fuel Rod",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 69.14,
                 "Bastium": 34.57,
@@ -812,15 +794,15 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Generator Fuel Chamber Tier 1",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
-                "Bastium": 202,
+                "Bastium": 202.0,
                 "Charodium": 403.99,
-                "Vokarium": 202
+                "Vokarium": 202.0
             },
             "Research": {
                 "Cube": 16,
@@ -829,11 +811,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Radiator Extension",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 16.9,
                 "Charodium": 42.25,
@@ -845,11 +827,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Radiator Base",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 44.88,
                 "Charodium": 112.21,
@@ -861,11 +843,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Small Rechargeable Battery",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 127.66,
                 "Nhurgite": 680.83,
@@ -878,24 +860,24 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Small Cooling Cell",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 14.64
-             },
+            },
             "Research": {
-               "Cube": 1
+                "Cube": 1
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Small Hydrogen Propellant Tank",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 180.12,
                 "Vokarium": 77.19
@@ -906,11 +888,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Triangle Thruster Base Tier 1",
-            "CraftingTime": 5,
+            "CraftingTime": 5.0,
             "Materials": {
                 "Bastium": 154.77,
                 "Charodium": 221.1,
@@ -922,11 +904,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Box Thruster Combustion Chamber",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 319.85,
                 "Charodium": 411.23,
@@ -939,11 +921,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Box Thruster Nozzle Tier 1",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 128.76,
                 "Charodium": 300.44
@@ -955,11 +937,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Triangle Thruster Nozzle Tier 1",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 56.65,
                 "Charodium": 105.21
@@ -971,11 +953,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Hinge B 48x144 cm",
-            "CraftingTime": 1,
+            "CraftingTime": 1.0,
             "Materials": {
                 "Ajatite": 13.21,
                 "Bastium": 4.07
@@ -986,11 +968,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Slider Basic A 48x144 cm",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 7.13,
                 "Bastium": 28.21,
@@ -1002,11 +984,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Hinge (L-profile) 24x144x36 cm",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 58.95
             },
@@ -1015,11 +997,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Hinge (C-profile) 48x144x36 cm",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 73.34
             },
@@ -1028,11 +1010,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Hinge A 48x144 cm",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Ajatite": 13.57,
                 "Bastium": 4.07
@@ -1043,11 +1025,11 @@
             },
             "Favourite": 0,
             "Hide": 1,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Pilot Chair Stand",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 35.76,
                 "Vokarium": 1.88
@@ -1058,11 +1040,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Material Point Scanner Fixed Mount",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Aegisium": 818.27,
                 "Bastium": 503.8,
@@ -1078,11 +1060,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Mining Laser Fixed Mount",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Aegisium": 517.6,
                 "Bastium": 2390.18,
@@ -1098,11 +1080,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Fixed Weapon Mount 2",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 66.07,
                 "Vokarium": 11.66
@@ -1113,11 +1095,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Material Point Scanner",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Aegisium": 300.67,
                 "Bastium": 257.73,
@@ -1132,11 +1114,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Mining Laser",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 2144.1,
                 "Charodium": 6003.24,
@@ -1151,11 +1133,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Small Turntable Mount 2",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 64.18
             },
@@ -1164,11 +1146,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Turret Cradle Advanced",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 338.64,
                 "Vokarium": 84.66
@@ -1180,11 +1162,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Turret Turntable",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 235.37
             },
@@ -1193,13 +1175,13 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Tripod",
-            "CraftingTime": 19,
+            "CraftingTime": 19.0,
             "Materials": {
-                "Ajatite": 517,
+                "Ajatite": 517.0,
                 "Bastium": 827.3,
                 "Charodium": 723.8
             },
@@ -1209,11 +1191,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Tripod Autocannon",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 463.6,
                 "Charodium": 2162.9,
@@ -1225,11 +1207,11 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
         },
         {
             "Name": "Tripod Autocannon Magazine",
-            "CraftingTime": 0,
+            "CraftingTime": 0.0,
             "Materials": {
                 "Bastium": 515.74,
                 "Ice": 75.2,
@@ -1241,7 +1223,450 @@
             },
             "Favourite": 0,
             "Hide": 0,
-            "VendorPrice": 0
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Station Foundation (Inside Safe Zone)",
+            "CraftingTime": 310.0,
+            "Materials": {
+                "Bastium": 3403.5,
+                "Charodium": 7597.42,
+                "Vokarium": 22792.27
+            },
+            "Research": {
+                "Cube": 688,
+                "Gear": 1376,
+                "Power": 1376
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 31390.88
+        },
+        {
+            "Name": "Station Foundation (Outside Safe Zone)",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Arkanium": 10256.52,
+                "Bastium": 3007.92,
+                "Kutonium": 8547.09,
+                "Vokarium": 26780.92
+            },
+            "Research": {
+                "Cube": 1154,
+                "Gear": 2309,
+                "Power": 2309
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Factory Hall Corner Beam",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Valkite": 113.91,
+                "Charodium": 493.63,
+                "Aegisium": 151.88
+            },
+            "Research": {
+                "Cube": 115,
+                "Gear": 11
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Factory Hall Corner Full",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Valkite": 353.54,
+                "Charodium": 1532.0,
+                "Aegisium": 471.38
+            },
+            "Research": {
+                "Cube": 360,
+                "Gear": 38
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Factory Hall Corner Half",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Valkite": 206.93,
+                "Charodium": 896.7,
+                "Aegisium": 275.91
+            },
+            "Research": {
+                "Cube": 210,
+                "Gear": 22
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Factory Hall Edge",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Valkite": 281.62,
+                "Charodium": 1220.36,
+                "Aegisium": 375.49
+            },
+            "Research": {
+                "Cube": 286,
+                "Gear": 31
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Factory Hall Edge Beam",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Valkite": 44.62,
+                "Charodium": 193.55,
+                "Aegisium": 59.49
+            },
+            "Research": {
+                "Cube": 45,
+                "Gear": 4
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Factory Hall Edge Flat",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Valkite": 170.79,
+                "Charodium": 740.1,
+                "Aegisium": 227.72
+            },
+            "Research": {
+                "Cube": 173,
+                "Gear": 18
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Factory Hall Flat",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Valkite": 192.4,
+                "Charodium": 833.73,
+                "Aegisium": 256.53
+            },
+            "Research": {
+                "Cube": 195,
+                "Gear": 21
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Factory Hall Ramp",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Valkite": 41.93,
+                "Bastium": 55.91,
+                "Charodium": 55.91
+            },
+            "Research": {
+                "Cube": 40,
+                "Gear": 3
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Advanced Crafting Bench",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Ajatite": 3645.8,
+                "Vokarium": 3645.8,
+                "Charodium": 6380.15,
+                "Bastium": 362.95
+            },
+            "Research": {
+                "Cube": 254,
+                "Power": 381,
+                "Gear": 637
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Advanced Crafting Bench Metal Bender Upgrade",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Vokarium": 1823.85,
+                "Charodium": 5471.55,
+                "Bastium": 1824.0
+            },
+            "Research": {
+                "Cube": 191,
+                "Power": 287,
+                "Gear": 480
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Advanced Crafting Bench Saw Upgrade",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Vokarium": 2736.75,
+                "Exorium": 2052.5,
+                "Charodium": 4789.25,
+                "Bastium": 4105.25
+            },
+            "Research": {
+                "Cube": 724,
+                "Gear": 724
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Basic Crafting Bench Soldering Iron Upgrade",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Karnite": 565.5,
+                "Vokarium": 209.25,
+                "Bastium": 524.25,
+                "Kutonium": 481.5,
+                "Charodium": 314.0
+            },
+            "Research": {
+                "Cube": 49,
+                "Power": 75,
+                "Gear": 127
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Reconstruction Machine Cradle Module",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Arkanium": 2305.08,
+                "Vokarium": 5762.7,
+                "Bastium": 223.78,
+                "Charodium": 2881.35,
+                "Aegisium": 3841.8
+            },
+            "Research": {
+                "Cube": 169,
+                "Shield": 855,
+                "Gear": 683
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Reconstruction Machine Fabricator Module",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Arkanium": 14244.35,
+                "Kutonium": 8953.59,
+                "Exorium": 11395.48,
+                "Bastium": 1910.43
+            },
+            "Research": {
+                "Cube": 499,
+                "Shield": 2505,
+                "Gear": 2005
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Reconstruction Machine Generator Module",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Aegisium": 3248.84,
+                "Vokarium": 4938.23,
+                "Charodium": 2858.97,
+                "Bastium": 1949.32
+            },
+            "Research": {
+                "Cube": 137,
+                "Shield": 691,
+                "Gear": 552
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Reconstruction Machine Terminal Module",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Ajatite": 3784.75,
+                "Arkanium": 9083.4,
+                "Vokarium": 7569.5,
+                "Bastium": 2965.65,
+                "Aegisium": 6055.6
+            },
+            "Research": {
+                "Cube": 329,
+                "Shield": 1656,
+                "Gear": 1324
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Small Navigation Receiver",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Ajatite": 59.61,
+                "Vokarium": 417.25,
+                "Charodium": 59.61,
+                "Bastium": 134.38
+            },
+            "Research": {
+                "Cube": 11,
+                "Power": 39,
+                "Gear": 10
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Solar Panel Support",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Vokarium": 259.27,
+                "Bastium": 777.79
+            },
+            "Research": {
+                "Cube": 61,
+                "Power": 20,
+                "Gear": 9
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Solar Panel Light Sensor",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Aegisium": 230.77,
+                "Vokarium": 115.39,
+                "Ymrium": 57.69,
+                "Charodium": 173.09
+            },
+            "Research": {
+                "Cube": 11,
+                "Power": 38,
+                "Gear": 11
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Solar Power Converter",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Arkanium": 334.8,
+                "Vokarium": 446.39,
+                "Bastium": 334.8,
+                "Aegisium": 1115.99
+            },
+            "Research": {
+                "Cube": 50,
+                "Power": 155,
+                "Gear": 50
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Ship Transponder",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Ajatite": 76.84,
+                "Vokarium": 230.54,
+                "Charodium": 204.94
+            },
+            "Research": {
+                "Cube": 4,
+                "Power": 43
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Endoskeleton Replacement Kit",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Arkanium": 566.15,
+                "Exorium": 377.44,
+                "Bastium": 1163.79,
+                "Charodium": 1037.95
+            },
+            "Research": {
+                "Cube": 105,
+                "Shield": 212,
+                "Gear": 34
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Navigation Receiver",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Ajatite": 155.04,
+                "Vokarium": 1085.27,
+                "Charodium": 155.04,
+                "Bastium": 387.25
+            },
+            "Research": {
+                "Cube": 35,
+                "Power": 101,
+                "Gear": 28
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Station Plate 216x432 cm",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Valkite": 582.67
+            },
+            "Research": {
+                "Cube": 291
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
         }
     ]
 }


### PR DESCRIPTION
Added data for the reconstruction machine parts, factory hall modules, navigation receivers, transponder, endo kit, advanced crafting bench, its upgrades, the soldering iron, solar panels, and... a single station plate. 

The reason I only added the ONE station plate is because it is the most efficient one, all station plates approach a 2:1 material to research ratio as their recipes require more kv, and since the most expensive one is still only like half a stack of valkite, I figured I wouldn't add 4k lines of data for all the other marginally cheaper plates that give you less research per stack anyway.

Also, all station modules approach the same ratio, but none ever top my good friend Plate 216x432. The "fancy" ones start needing Ajatite too, which just further decreases their research value. 