### PR TITLE
Minor Recipe Fixes and Research Node Data

### DIFF
--- a/ResearchNodes.json
+++ b/ResearchNodes.json
@@ -1,0 +1,1370 @@
+{
+    "objects": [
+        {
+            "Name": "Advanced Crafting Bench",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [
+                "Advanced Crafting Bench"
+            ],
+            "Dependencies": [],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Advanced Bench Metal Bender Upgrade",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [
+                "Advanced Crafting Bench Metal Bender Upgrade"
+            ],
+            "Dependencies": [
+                "Advanced Crafting Bench"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Plates",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [
+                "Station Plate 216x432 cm"
+            ],
+            "Dependencies": [
+                "Advanced Bench Metal Bender Upgrade"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Beams",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Advanced Bench Metal Bender Upgrade"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Corner",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Station Plates",
+                "Station Beams"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Slanted",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Station Plates",
+                "Station Beams"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Angled",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Station Plates",
+                "Station Beams"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Decorative",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Station Plates"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Misc.",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Station Slanted"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Windows",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Station Angled"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Foundation (Inside Safe Zone)",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [
+                "Station Foundation (Inside Safe Zone)"
+            ],
+            "Dependencies": [
+                "Advanced Crafting Bench"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Basic Frames",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Station Foundation (Inside Safe Zone)"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Basic Block Modules",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Station Foundation (Inside Safe Zone)"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Factory Hall",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [
+                "Factory Hall Corner Beam",
+                "Factory Hall Corner Half",
+                "Factory Hall Corner Full",
+                "Factory Hall Edge",
+                "Factory Hall Edge Beam",
+                "Factory Hall Edge Flat",
+                "Factory Hall Flat",
+                "Factory Hall Ramp"
+            ],
+            "Dependencies": [
+                "Basic Block Modules",
+                "Basic Frames"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Advanced Bench Metal Saw Upgrade",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [
+                "Advanced Crafting Bench Metal Saw Upgrade"
+            ],
+            "Dependencies": [
+                "Factory Hall"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Decorative Module Bundle 1",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Advanced Bench Metal Saw Upgrade"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Decorative Module Bundle 2",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Advanced Bench Metal Saw Upgrade"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Decorative Module Bundle 3",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Decorative Module Bundle 1"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Decorative Module Bundle 4",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Decorative Module Bundle 2"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Solar Panels",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [
+                "Solar Panel Support",
+                "Solar Panel Light Sensor",
+                "Solar Power Converter"
+            ],
+            "Dependencies": [
+                "Decorative Module Bundle 3",
+                "Decorative Module Bundle 4"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Station Foundation (Outside Safe Zone)",
+            "Tree": "Advanced",
+            "IsOwned": false,
+            "Recipes": [
+                "Station Foundation (Outside Safe Zone)"
+            ],
+            "Dependencies": [
+                "Solar Panels"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Tools & Weapons Crafting Bench",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [
+                "Tools & Weapons Crafting Bench"
+            ],
+            "Dependencies": [],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Pickaxe",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tools & Weapons Crafting Bench"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Welding Tool",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tools & Weapons Crafting Bench"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Infantry Basics",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tools & Weapons Crafting Bench"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Buzzsaw",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Pickaxe",
+                "Welding Tool"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Bolt Tool",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Pickaxe",
+                "Welding Tool"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Cable Tool",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Pickaxe",
+                "Welding Tool"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Cutting Tool",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Buzzsaw"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Building Tool",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Bolt Tool"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Pipe Tool",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cable Tool"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Tools & Weapons Bench Small Clamp Upgrade",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cutting Tool",
+                "Building Tool",
+                "Pipe Tool"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Socket Tool",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tools & Weapons Bench Small Clamp Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 10000,
+                "Power": 12500
+            }
+        },
+        {
+            "Name": "Paint Tool",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Socket Tool"
+            ],
+            "ResearchCosts": {
+                "Cube": 7500,
+                "Shield": 20000,
+                "Gear": 35000
+            }
+        },
+        {
+            "Name": "Brown 1",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Paint Tool"
+            ],
+            "ResearchCosts": {
+                "Cube": 4000,
+                "Power": 2000,
+                "Shield": 2000
+            }
+        },
+        {
+            "Name": "Yellow 1",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Paint Tool"
+            ],
+            "ResearchCosts": {
+                "Power": 10000
+            }
+        },
+        {
+            "Name": "Green 1",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Paint Tool"
+            ],
+            "ResearchCosts": {
+                "Power": 4000,
+                "Shield": 4000
+            }
+        },
+        {
+            "Name": "Red 1",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Brown 1"
+            ],
+            "ResearchCosts": {
+                "Cube": 20000
+            }
+        },
+        {
+            "Name": "Blue 1",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Yellow 1"
+            ],
+            "ResearchCosts": {
+                "Shield": 10000
+            }
+        },
+        {
+            "Name": "Gray 1",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Green 1"
+            ],
+            "ResearchCosts": {
+                "Cube": 2500,
+                "Power": 2500,
+                "Shield": 2500,
+                "Gear": 2500
+            }
+        },
+        {
+            "Name": "Bright Reds",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Red 1",
+                "Blue 1",
+                "Gray 1"
+            ],
+            "ResearchCosts": {
+                "Cube": 25000,
+                "Gear": 25000
+            }
+        },
+        {
+            "Name": "Bright Blues",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Red 1",
+                "Blue 1",
+                "Gray 1"
+            ],
+            "ResearchCosts": {
+                "Power": 10000,
+                "Shield": 30000
+            }
+        },
+        {
+            "Name": "White 1",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Red 1",
+                "Blue 1",
+                "Gray 1"
+            ],
+            "ResearchCosts": {
+                "Cube": 10000,
+                "Power": 10000,
+                "Shield": 10000,
+                "Gear": 10000
+            }
+        },
+        {
+            "Name": "Black 1",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Red 1",
+                "Blue 1",
+                "Gray 1"
+            ],
+            "ResearchCosts": {
+                "Cube": 10000,
+                "Power": 10000,
+                "Shield": 10000,
+                "Gear": 10000
+            }
+        },
+        {
+            "Name": "Shotgun",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Infantry Basics"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Long Rifle",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Infantry Basics"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Repeater Pistol",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Long Rifle"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Revolver",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Repeater Pistol"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Tools & Weapons Bench Rifle Clamp Upgrade",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Remote Explosives"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Remote Explosives",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Shotgun",
+                "Long Rifle"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Plasma Rifle",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tools & Weapons Bench Rifle Clamp Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 20000,
+                "Power": 20000,
+                "Shield": 35000
+            }
+        },
+        {
+            "Name": "Battle Rifle",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tools & Weapons Bench Rifle Clamp Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 20000,
+                "Shield": 35000,
+                "Gear": 10000
+            }
+        },
+        {
+            "Name": "Bolter",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tools & Weapons Bench Rifle Clamp Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 20000,
+                "Shield": 45000
+            }
+        },
+        {
+            "Name": "Grenade Launcher",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tools & Weapons Bench Rifle Clamp Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 25000,
+                "Shield": 55000,
+                "Gear": 20000
+            }
+        },
+        {
+            "Name": "Rocket Launcher",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Grenade Launcher"
+            ],
+            "ResearchCosts": {
+                "Cube": 50000,
+                "Shield": 75000,
+                "Gear": 25000
+            }
+        },
+        {
+            "Name": "Rail Rifle",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Bolter"
+            ],
+            "ResearchCosts": {
+                "Cube": 40000,
+                "Shield": 60000
+            }
+        },
+        {
+            "Name": "Laser Rifle",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Plasma Rifle",
+                "Battle Rifle"
+            ],
+            "ResearchCosts": {
+                "Cube": 20000,
+                "Power": 35000,
+                "Shield": 40000
+            }
+        },
+        {
+            "Name": "Gauss Rifle",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Laser Rifle"
+            ],
+            "ResearchCosts": {
+                "Cube": 80000,
+                "Shield": 20000
+            }
+        },
+        {
+            "Name": "Antigel Rifle",
+            "Tree": "Tools/Weap.",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Laser Rifle"
+            ],
+            "ResearchCosts": {
+                "Cube": 60000,
+                "Shield": 60000
+            }
+        },
+        {
+            "Name": "Basic Crafting Bench",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [
+                "Basic Crafting Bench"
+            ],
+            "Dependencies": [],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Windows",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Basic Crafting Bench"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Basic",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Basic Crafting Bench"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Extension and Adapter Modules",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Basic Crafting Bench"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Cargo Box",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Basic"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Extra Plates Bundle",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cargo Box"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Extra Beams Bundle",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Extra Plates Bundle"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Control Tables, Screens, Small Devices",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cargo Box"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Hinges & Hatches",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Control Tables, Screens, Small Devices"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Tier 1 Thrusters",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cargo Box"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Tier 1 Generators",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cargo Box"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Fuel Rods",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cargo Box"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Small Propellant Tank",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Fuel Rods"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Radiators",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tier 1 Generators"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Cockpit Modules",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tier 1 Generators",
+                "Tier 1 Thrusters",
+                "Fuel Rods"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Basic Yolol Chip",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cockpit Modules"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Ship Diagnostic Scanner",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cockpit Modules"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Material Point Scanner",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cockpit Modules"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Tripod Autocannon",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Cockpit Modules"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Mounted Autocannon",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tripod Autocannon"
+            ],
+            "ResearchCosts": {
+                "Cube": 30000,
+                "Shield": 10000,
+                "Gear": 30000
+            }
+        },
+        {
+            "Name": "Weapons and Tools Bench Large Clamp Upgrade",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Mounted Autocannon"
+            ],
+            "ResearchCosts": {
+                "Cube": 5000,
+                "Power": 5000,
+                "Shield": 5000,
+                "Gear": 5000
+            }
+        },
+        {
+            "Name": "Mounted Plasma Cannon",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Weapons and Tools Bench Large Clamp Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 80000,
+                "Shield": 50000
+            }
+        },
+        {
+            "Name": "Mounted Laser Cannon",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Weapons and Tools Bench Large Clamp Upgrade"
+            ],
+            "ResearchCosts": {
+                "Power": 80000,
+                "Shield": 80000,
+                "Gear": 60000
+            }
+        },
+        {
+            "Name": "Missles",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Mounted Plasma Cannon"
+            ],
+            "ResearchCosts": {
+                "Cube": 100000,
+                "Shield": 100000
+            }
+        },
+        {
+            "Name": "Torpedoes",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Mounted Laser Cannon"
+            ],
+            "ResearchCosts": {
+                "Power": 100000,
+                "Shield": 100000,
+                "Gear": 100000
+            }
+        },
+        {
+            "Name": "Mounted Railgun",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Missles",
+                "Torpedoes"
+            ],
+            "ResearchCosts": {
+                "Cube": 100000,
+                "Power": 100000,
+                "Shield": 100000,
+                "Gear": 100000
+            }
+        },
+        {
+            "Name": "Ore Collector",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Material Point Scanner"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Mining Laser",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Material Point Scanner"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Crafting Bench Cables Upgrade",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Ore Collector",
+                "Mining Laser"
+            ],
+            "ResearchCosts": {
+                "Cube": 2000,
+                "Power": 4500,
+                "Shield": 1000,
+                "Gear": 5000
+            }
+        },
+        {
+            "Name": "Rangefinder",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Crafting Bench Cables Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 8000,
+                "Power": 5000
+            }
+        },
+        {
+            "Name": "Laser Designator",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Crafting Bench Cables Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 10000,
+                "Power": 6000,
+                "Shield": 6000
+            }
+        },
+        {
+            "Name": "Tractor Beam",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Rangefinder",
+                "Laser Designator"
+            ],
+            "ResearchCosts": {
+                "Cube": 6000,
+                "Power": 12000,
+                "Gear": 24000
+            }
+        },
+        {
+            "Name": "Cargo Lock Beam",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tractor Beam"
+            ],
+            "ResearchCosts": {
+                "Cube": 8000,
+                "Power": 5000,
+                "Gear": 10000
+            }
+        },
+        {
+            "Name": "Cargo Lock Frame",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tractor Beam"
+            ],
+            "ResearchCosts": {
+                "Cube": 6000,
+                "Power": 8000,
+                "Gear": 10000
+            }
+        },
+        {
+            "Name": "Crafting Bench Meter Upgrade",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Ship Diagnostic Scanner"
+            ],
+            "ResearchCosts": {
+                "Cube": 3000,
+                "Power": 1000,
+                "Gear": 2000
+            }
+        },
+        {
+            "Name": "Tier 2 Generator",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Crafting Bench Meter Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 12000,
+                "Power": 6000,
+                "Gear": 6000
+            }
+        },
+        {
+            "Name": "Tier 2 Thrusters",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Crafting Bench Meter Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 10000,
+                "Power": 5000,
+                "Gear": 10000
+            }
+        },
+        {
+            "Name": "Advanced Flight Control Unit",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tier 2 Generator"
+            ],
+            "ResearchCosts": {
+                "Cube": 6000,
+                "Power": 8000,
+                "Gear": 5000
+            }
+        },
+        {
+            "Name": "Medium Propellant Tank",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tier 2 Thrusters"
+            ],
+            "ResearchCosts": {
+                "Cube": 20000,
+                "Gear": 6000
+            }
+        },
+        {
+            "Name": "Fast Travel Core",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Advanced Flight Control Unit",
+                "Medium Propellant Tank"
+            ],
+            "ResearchCosts": {
+                "Cube": 5000,
+                "Power": 5000,
+                "Gear": 15000
+            }
+        },
+        {
+            "Name": "Crafting Bench Monitor Upgrade",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Fast Travel Core"
+            ],
+            "ResearchCosts": {
+                "Cube": 30000,
+                "Power": 40000,
+                "Gear": 80000
+            }
+        },
+        {
+            "Name": "Premium Flight Control Unit",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Crafting Bench Monitor Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 10000,
+                "Power": 20000,
+                "Gear": 25000
+            }
+        },
+        {
+            "Name": "Tier 3 Generator",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Crafting Bench Monitor Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 25000,
+                "Power": 35000,
+                "Gear": 35000
+            }
+        },
+        {
+            "Name": "Tier 3 Thrusters",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Crafting Bench Monitor Upgrade"
+            ],
+            "ResearchCosts": {
+                "Cube": 20000,
+                "Power": 20000,
+                "Gear": 20000
+            }
+        },
+        {
+            "Name": "Large Propellant Tank",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Tier 3 Thrusters"
+            ],
+            "ResearchCosts": {
+                "Cube": 20000,
+                "Power": 20000,
+                "Gear": 20000
+            }
+        },
+        {
+            "Name": "Plasma Thruster",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Large Propellant Tank"
+            ],
+            "ResearchCosts": {
+                "Cube": 30000,
+                "Power": 30000,
+                "Gear": 30000
+            }
+        },
+        {
+            "Name": "Yolol Rack Chip Reader",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Basic Yolol Chip"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Navigation Receivers & Transponders",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Basic Yolol Chip"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Audio Signal Device",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Navigation Receivers & Transponders"
+            ],
+            "ResearchCosts": {
+                "Cube": 1000,
+                "Power": 2000
+            }
+        },
+        {
+            "Name": "Crafting Bench Soldering Iron Upgrade",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Yolol Rack Chip Reader",
+                "Navigation Receivers & Transponders"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Advanced Yolol Chip",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Crafting Bench Soldering Iron Upgrade"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Yolol Memory Chip",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Advanced Yolol Chip"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Network Relay",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Advanced Yolol Chip"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Professional Yolol Chip",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Yolol Memory Chip",
+                "Network Relay"
+            ],
+            "ResearchCosts": {}
+        },
+        {
+            "Name": "Reconstruction Machine",
+            "Tree": "Basic",
+            "IsOwned": false,
+            "Recipes": [],
+            "Dependencies": [
+                "Professional Yolol Chip"
+            ],
+            "ResearchCosts": {}
+        }
+    ]
+}

--- a/ResearchNodes.json
+++ b/ResearchNodes.json
@@ -12,7 +12,11 @@
                 "Advanced Bench Metal Bender Upgrade",
                 "Station Foundation (Inside Safe Zone)"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 2000,
+                "Power": 2000,
+                "Gear": 2000
+            }
         },
         {
             "Name": "Advanced Bench Metal Bender Upgrade",
@@ -28,7 +32,11 @@
                 "Station Plates",
                 "Station Beams"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 2000,
+                "Power": 2000,
+                "Gear": 2000
+            }
         },
         {
             "Name": "Station Plates",
@@ -45,7 +53,9 @@
                 "Station Slanted",
                 "Station Angled"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 5000
+            }
         },
         {
             "Name": "Station Beams",
@@ -60,7 +70,9 @@
                 "Station Slanted",
                 "Station Angled"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 15000
+            }
         },
         {
             "Name": "Station Corner",
@@ -74,7 +86,9 @@
             "Children": [
                 "Station Decorative"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 15000
+            }
         },
         {
             "Name": "Station Slanted",
@@ -88,7 +102,9 @@
             "Children": [
                 "Station Misc."
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 15000
+            }
         },
         {
             "Name": "Station Angled",
@@ -102,7 +118,9 @@
             "Children": [
                 "Station Windows"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 150000
+            }
         },
         {
             "Name": "Station Decorative",
@@ -113,7 +131,9 @@
                 "Station Corner"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 20000
+            }
         },
         {
             "Name": "Station Misc.",
@@ -124,7 +144,9 @@
                 "Station Slanted"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 20000
+            }
         },
         {
             "Name": "Station Windows",
@@ -135,7 +157,9 @@
                 "Station Angled"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 20000
+            }
         },
         {
             "Name": "Station Foundation (Inside Safe Zone)",
@@ -151,7 +175,10 @@
                 "Basic Frames",
                 "Basic Block Modules"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Power": 2000,
+                "Gear": 2000
+            }
         },
         {
             "Name": "Basic Frames",
@@ -164,7 +191,11 @@
             "Children": [
                 "Factory Hall"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Power": 2000,
+                "Gear": 2000,
+                "Cube": 2000
+            }
         },
         {
             "Name": "Basic Block Modules",
@@ -177,7 +208,9 @@
             "Children": [
                 "Factory Hall"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 1000
+            }
         },
         {
             "Name": "Factory Hall",
@@ -200,7 +233,10 @@
             "Children": [
                 "Advanced Bench Metal Saw Upgrade"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 20000,
+                "Gear": 2000
+            }
         },
         {
             "Name": "Advanced Bench Metal Saw Upgrade",
@@ -216,7 +252,11 @@
                 "Decorative Module Bundle 1",
                 "Decorative Module Bundle 2"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 10000,
+                "Power": 1000,
+                "Gear": 2000
+            }
         },
         {
             "Name": "Decorative Module Bundle 1",
@@ -229,7 +269,9 @@
             "Children": [
                 "Decorative Module Bundle 3"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 20000
+            }
         },
         {
             "Name": "Decorative Module Bundle 2",
@@ -242,7 +284,9 @@
             "Children": [
                 "Decorative Module Bundle 4"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 20000
+            }
         },
         {
             "Name": "Decorative Module Bundle 3",
@@ -255,7 +299,9 @@
             "Children": [
                 "Solar Panels"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 25000
+            }
         },
         {
             "Name": "Decorative Module Bundle 4",
@@ -268,7 +314,9 @@
             "Children": [
                 "Solar Panels"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 25000
+            }
         },
         {
             "Name": "Solar Panels",
@@ -286,7 +334,10 @@
             "Children": [
                 "Station Foundation (Outside Safe Zone)"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 50000,
+                "Power": 20000
+            }
         },
         {
             "Name": "Station Foundation (Outside Safe Zone)",
@@ -299,7 +350,10 @@
                 "Solar Panels"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 100000,
+                "Gear": 20000
+            }
         },
         {
             "Name": "Tools & Weapons Crafting Bench",
@@ -314,7 +368,10 @@
                 "Welding Tool",
                 "Infantry Basics"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Power": 1000,
+                "Gear": 2000
+            }
         },
         {
             "Name": "Pickaxe",
@@ -329,7 +386,9 @@
                 "Bolt Tool",
                 "Cable Tool"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 400
+            }
         },
         {
             "Name": "Welding Tool",
@@ -346,7 +405,10 @@
                 "Bolt Tool",
                 "Cable Tool"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 250,
+                "Power": 250
+            }
         },
         {
             "Name": "Infantry Basics",
@@ -362,7 +424,10 @@
                 "Shotgun",
                 "Long Rifle"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Shield": 200,
+                "Gear": 1000
+            }
         },
         {
             "Name": "Buzzsaw",
@@ -378,7 +443,12 @@
             "Children": [
                 "Cutting Tool"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 250,
+                "Power": 200,
+                "Shield": 150,
+                "Gear": 200
+            }
         },
         {
             "Name": "Bolt Tool",
@@ -395,7 +465,10 @@
             "Children": [
                 "Building Tool"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 225,
+                "Gear": 450
+            }
         },
         {
             "Name": "Cable Tool",
@@ -409,7 +482,10 @@
             "Children": [
                 "Pipe Tool"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 200,
+                "Power": 500
+            }
         },
         {
             "Name": "Cutting Tool",
@@ -424,7 +500,12 @@
             "Children": [
                 "Tools & Weapons Bench Small Clamp Upgrade"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 1000,
+                "Power": 500,
+                "Shield": 300,
+                "Gear": 1000
+            }
         },
         {
             "Name": "Building Tool",
@@ -437,7 +518,11 @@
             "Children": [
                 "Tools & Weapons Bench Small Clamp Upgrade"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 500,
+                "Power": 500,
+                "Gear": 500
+            }
         },
         {
             "Name": "Pipe Tool",
@@ -452,7 +537,11 @@
             "Children": [
                 "Tools & Weapons Bench Small Clamp Upgrade"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 200,
+                "Power": 500,
+                "Gear": 300
+            }
         },
         {
             "Name": "Tools & Weapons Bench Small Clamp Upgrade",
@@ -469,7 +558,12 @@
             "Children": [
                 "Socket Tool"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 2500,
+                "Shield": 2500,
+                "Power": 2500,
+                "Gear": 2500
+            }
         },
         {
             "Name": "Socket Tool",
@@ -690,7 +784,10 @@
             "Children": [
                 "Remote Explosives"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 5000,
+                "Shield": 10000
+            }
         },
         {
             "Name": "Long Rifle",
@@ -703,7 +800,10 @@
             "Children": [
                 "Repeater Pistol"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 5000,
+                "Shield": 10000
+            }
         },
         {
             "Name": "Repeater Pistol",
@@ -716,7 +816,10 @@
             "Children": [
                 "Revolver"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 5000,
+                "Shield": 7500
+            }
         },
         {
             "Name": "Revolver",
@@ -727,7 +830,10 @@
                 "Repeater Pistol"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 5000,
+                "Shield": 12000
+            }
         },
         {
             "Name": "Tools & Weapons Bench Rifle Clamp Upgrade",
@@ -745,7 +851,10 @@
                 "Bolter",
                 "Grenade Launcher"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 25000,
+                "Shield": 50000
+            }
         },
         {
             "Name": "Remote Explosives",
@@ -758,7 +867,10 @@
             "Children": [
                 "Tools & Weapons Bench Rifle Clamp Upgrade"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 15000,
+                "Shield": 30000
+            }
         },
         {
             "Name": "Plasma Rifle",
@@ -814,7 +926,10 @@
             "Name": "Grenade Launcher",
             "Tree": "Tools/Weap.",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Grenade",
+                "Grenade Launcher"
+            ],
             "Dependencies": [
                 "Tools & Weapons Bench Rifle Clamp Upgrade"
             ],
@@ -906,7 +1021,7 @@
         {
             "Name": "Basic Crafting Bench",
             "Tree": "Basic",
-            "IsOwned": false,
+            "IsOwned": true,
             "Recipes": [
                 "Basic Crafting Bench"
             ],
@@ -927,7 +1042,9 @@
                 "Basic Crafting Bench"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 300
+            }
         },
         {
             "Name": "Basic",
@@ -949,7 +1066,9 @@
             "Children": [
                 "Cargo Box"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 60
+            }
         },
         {
             "Name": "Extension and Adapter Modules",
@@ -974,7 +1093,9 @@
                 "Basic Crafting Bench"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 300
+            }
         },
         {
             "Name": "Cargo Box",
@@ -998,7 +1119,10 @@
                 "Tier 1 Generators",
                 "Fuel Rods"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 300,
+                "Gear": 50
+            }
         },
         {
             "Name": "Extra Plates Bundle",
@@ -1011,7 +1135,9 @@
             "Children": [
                 "Extra Beams Bundle"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 1000
+            }
         },
         {
             "Name": "Extra Beams Bundle",
@@ -1022,7 +1148,9 @@
                 "Extra Plates Bundle"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 1500
+            }
         },
         {
             "Name": "Control Tables, Screens, Small Devices",
@@ -1041,7 +1169,10 @@
             "Children": [
                 "Hinges & Hatches"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Power": 100,
+                "Gear": 100
+            }
         },
         {
             "Name": "Hinges & Hatches",
@@ -1058,7 +1189,11 @@
                 "Control Tables, Screens, Small Devices"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 800,
+                "Power": 150,
+                "Gear": 100
+            }
         },
         {
             "Name": "Tier 1 Thrusters",
@@ -1079,7 +1214,11 @@
             "Children": [
                 "Cockpit Modules"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 500,
+                "Power": 100,
+                "Gear": 300
+            }
         },
         {
             "Name": "Tier 1 Generators",
@@ -1097,7 +1236,11 @@
                 "Radiators",
                 "Cockpit Modules"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 1000,
+                "Power": 300,
+                "Gear": 1000
+            }
         },
         {
             "Name": "Fuel Rods",
@@ -1114,7 +1257,11 @@
                 "Small Propellant Tank",
                 "Cockpit Modules"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 300,
+                "Power": 50,
+                "Gear": 300
+            }
         },
         {
             "Name": "Small Propellant Tank",
@@ -1127,7 +1274,11 @@
                 "Fuel Rods"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 1000,
+                "Power": 500,
+                "Gear": 1000
+            }
         },
         {
             "Name": "Radiators",
@@ -1141,7 +1292,11 @@
                 "Tier 1 Generators"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 300,
+                "Power": 50,
+                "Gear": 200
+            }
         },
         {
             "Name": "Cockpit Modules",
@@ -1166,7 +1321,11 @@
                 "Ship Diagnostic Scanner",
                 "Material Point Scanner"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 1000,
+                "Power": 1000,
+                "Gear": 1000
+            }
         },
         {
             "Name": "Basic Yolol Chip",
@@ -1177,10 +1336,13 @@
                 "Cockpit Modules"
             ],
             "Children": [
-                "Yolol Rack Chip Reader",
+                "Yolol Rack Chip Readers",
                 "Navigation Receivers & Transponders"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 500,
+                "Power": 1000
+            }
         },
         {
             "Name": "Ship Diagnostic Scanner",
@@ -1195,7 +1357,10 @@
             "Children": [
                 "Crafting Bench Meter Upgrade"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 1000,
+                "Power": 4000
+            }
         },
         {
             "Name": "Material Point Scanner",
@@ -1216,7 +1381,10 @@
                 "Mining Laser",
                 "Ore Collector"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Power": 1000,
+                "Gear": 500
+            }
         },
         {
             "Name": "Tripod Autocannon",
@@ -1233,7 +1401,11 @@
             "Children": [
                 "Mounted Autocannon"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 5000,
+                "Shield": 1000,
+                "Gear": 5000
+            }
         },
         {
             "Name": "Mounted Autocannon",
@@ -1365,7 +1537,10 @@
             "Children": [
                 "Crafting Bench Cables Upgrade"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 2000,
+                "Gear": 2000
+            }
         },
         {
             "Name": "Mining Laser",
@@ -1381,7 +1556,11 @@
             "Children": [
                 "Crafting Bench Cables Upgrade"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 2000,
+                "Power": 1000,
+                "Gear": 2000
+            }
         },
         {
             "Name": "Crafting Bench Cables Upgrade",
@@ -1703,7 +1882,7 @@
             }
         },
         {
-            "Name": "Yolol Rack Chip Reader",
+            "Name": "Yolol Rack Chip Readers",
             "Tree": "Basic",
             "IsOwned": false,
             "Recipes": [],
@@ -1713,7 +1892,10 @@
             "Children": [
                 "Crafting Bench Soldering Iron Upgrade"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 2000,
+                "Power": 3000
+            }
         },
         {
             "Name": "Navigation Receivers & Transponders",
@@ -1730,7 +1912,11 @@
             "Children": [
                 "Audio Signal Device"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 1500,
+                "Power": 2000,
+                "Gear": 2000
+            }
         },
         {
             "Name": "Audio Signal Device",
@@ -1754,12 +1940,15 @@
                 "Basic Crafting Bench Soldering Iron Upgrade"
             ],
             "Dependencies": [
-                "Yolol Rack Chip Reader"
+                "Yolol Rack Chip Readers"
             ],
             "Children": [
                 "Advanced Yolol Chip"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 6000,
+                "Power": 6000
+            }
         },
         {
             "Name": "Advanced Yolol Chip",
@@ -1773,7 +1962,10 @@
                 "Network Relay",
                 "Yolol Memory Chip"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 6000,
+                "Power": 5000
+            }
         },
         {
             "Name": "Yolol Memory Chip",
@@ -1786,7 +1978,10 @@
             "Children": [
                 "Professional Yolol Chip"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 7500,
+                "Power": 2500
+            }
         },
         {
             "Name": "Network Relay",
@@ -1799,7 +1994,10 @@
             "Children": [
                 "Professional Yolol Chip"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 9000,
+                "Gear": 6000
+            }
         },
         {
             "Name": "Professional Yolol Chip",
@@ -1813,7 +2011,10 @@
             "Children": [
                 "Reconstruction Machine"
             ],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 10000,
+                "Power": 15000
+            }
         },
         {
             "Name": "Reconstruction Machine",
@@ -1830,7 +2031,12 @@
                 "Professional Yolol Chip"
             ],
             "Children": [],
-            "ResearchCosts": {}
+            "ResearchCosts": {
+                "Cube": 10000,
+                "Power": 10000,
+                "Shield": 5000,
+                "Gear": 10000
+            }
         }
     ]
 }

--- a/ResearchNodes.json
+++ b/ResearchNodes.json
@@ -8,6 +8,10 @@
                 "Advanced Crafting Bench"
             ],
             "Dependencies": [],
+            "Children": [
+                "Advanced Bench Metal Bender Upgrade",
+                "Station Foundation (Inside Safe Zone)"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -19,6 +23,10 @@
             ],
             "Dependencies": [
                 "Advanced Crafting Bench"
+            ],
+            "Children": [
+                "Station Plates",
+                "Station Beams"
             ],
             "ResearchCosts": {}
         },
@@ -32,6 +40,11 @@
             "Dependencies": [
                 "Advanced Bench Metal Bender Upgrade"
             ],
+            "Children": [
+                "Station Corner",
+                "Station Slanted",
+                "Station Angled"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -41,6 +54,11 @@
             "Recipes": [],
             "Dependencies": [
                 "Advanced Bench Metal Bender Upgrade"
+            ],
+            "Children": [
+                "Station Corner",
+                "Station Slanted",
+                "Station Angled"
             ],
             "ResearchCosts": {}
         },
@@ -53,6 +71,9 @@
                 "Station Plates",
                 "Station Beams"
             ],
+            "Children": [
+                "Station Decorative"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -63,6 +84,9 @@
             "Dependencies": [
                 "Station Plates",
                 "Station Beams"
+            ],
+            "Children": [
+                "Station Misc."
             ],
             "ResearchCosts": {}
         },
@@ -75,6 +99,9 @@
                 "Station Plates",
                 "Station Beams"
             ],
+            "Children": [
+                "Station Windows"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -83,8 +110,9 @@
             "IsOwned": false,
             "Recipes": [],
             "Dependencies": [
-                "Station Plates"
+                "Station Corner"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
@@ -95,6 +123,7 @@
             "Dependencies": [
                 "Station Slanted"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
@@ -105,6 +134,7 @@
             "Dependencies": [
                 "Station Angled"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
@@ -117,6 +147,10 @@
             "Dependencies": [
                 "Advanced Crafting Bench"
             ],
+            "Children": [
+                "Basic Frames",
+                "Basic Block Modules"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -127,6 +161,9 @@
             "Dependencies": [
                 "Station Foundation (Inside Safe Zone)"
             ],
+            "Children": [
+                "Factory Hall"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -136,6 +173,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Station Foundation (Inside Safe Zone)"
+            ],
+            "Children": [
+                "Factory Hall"
             ],
             "ResearchCosts": {}
         },
@@ -157,6 +197,9 @@
                 "Basic Block Modules",
                 "Basic Frames"
             ],
+            "Children": [
+                "Advanced Bench Metal Saw Upgrade"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -169,6 +212,10 @@
             "Dependencies": [
                 "Factory Hall"
             ],
+            "Children": [
+                "Decorative Module Bundle 1",
+                "Decorative Module Bundle 2"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -178,6 +225,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Advanced Bench Metal Saw Upgrade"
+            ],
+            "Children": [
+                "Decorative Module Bundle 3"
             ],
             "ResearchCosts": {}
         },
@@ -189,6 +239,9 @@
             "Dependencies": [
                 "Advanced Bench Metal Saw Upgrade"
             ],
+            "Children": [
+                "Decorative Module Bundle 4"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -199,6 +252,9 @@
             "Dependencies": [
                 "Decorative Module Bundle 1"
             ],
+            "Children": [
+                "Solar Panels"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -208,6 +264,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Decorative Module Bundle 2"
+            ],
+            "Children": [
+                "Solar Panels"
             ],
             "ResearchCosts": {}
         },
@@ -224,6 +283,9 @@
                 "Decorative Module Bundle 3",
                 "Decorative Module Bundle 4"
             ],
+            "Children": [
+                "Station Foundation (Outside Safe Zone)"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -236,6 +298,7 @@
             "Dependencies": [
                 "Solar Panels"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
@@ -246,6 +309,11 @@
                 "Tools & Weapons Crafting Bench"
             ],
             "Dependencies": [],
+            "Children": [
+                "Pickaxe",
+                "Welding Tool",
+                "Infantry Basics"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -256,15 +324,27 @@
             "Dependencies": [
                 "Tools & Weapons Crafting Bench"
             ],
+            "Children": [
+                "Buzzsaw",
+                "Bolt Tool",
+                "Cable Tool"
+            ],
             "ResearchCosts": {}
         },
         {
             "Name": "Welding Tool",
             "Tree": "Tools/Weap.",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Power Pack"
+            ],
             "Dependencies": [
                 "Tools & Weapons Crafting Bench"
+            ],
+            "Children": [
+                "Buzzsaw",
+                "Bolt Tool",
+                "Cable Tool"
             ],
             "ResearchCosts": {}
         },
@@ -272,9 +352,15 @@
             "Name": "Infantry Basics",
             "Tree": "Tools/Weap.",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Assault Rifle Magazine"
+            ],
             "Dependencies": [
                 "Tools & Weapons Crafting Bench"
+            ],
+            "Children": [
+                "Shotgun",
+                "Long Rifle"
             ],
             "ResearchCosts": {}
         },
@@ -282,10 +368,15 @@
             "Name": "Buzzsaw",
             "Tree": "Tools/Weap.",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Power Pack"
+            ],
             "Dependencies": [
                 "Pickaxe",
                 "Welding Tool"
+            ],
+            "Children": [
+                "Cutting Tool"
             ],
             "ResearchCosts": {}
         },
@@ -293,10 +384,16 @@
             "Name": "Bolt Tool",
             "Tree": "Tools/Weap.",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Bolt Tool Magazine",
+                "Bolt Tool"
+            ],
             "Dependencies": [
                 "Pickaxe",
                 "Welding Tool"
+            ],
+            "Children": [
+                "Building Tool"
             ],
             "ResearchCosts": {}
         },
@@ -309,15 +406,23 @@
                 "Pickaxe",
                 "Welding Tool"
             ],
+            "Children": [
+                "Pipe Tool"
+            ],
             "ResearchCosts": {}
         },
         {
             "Name": "Cutting Tool",
             "Tree": "Tools/Weap.",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Power Pack"
+            ],
             "Dependencies": [
                 "Buzzsaw"
+            ],
+            "Children": [
+                "Tools & Weapons Bench Small Clamp Upgrade"
             ],
             "ResearchCosts": {}
         },
@@ -329,15 +434,23 @@
             "Dependencies": [
                 "Bolt Tool"
             ],
+            "Children": [
+                "Tools & Weapons Bench Small Clamp Upgrade"
+            ],
             "ResearchCosts": {}
         },
         {
             "Name": "Pipe Tool",
             "Tree": "Tools/Weap.",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Pipe Tool"
+            ],
             "Dependencies": [
                 "Cable Tool"
+            ],
+            "Children": [
+                "Tools & Weapons Bench Small Clamp Upgrade"
             ],
             "ResearchCosts": {}
         },
@@ -345,11 +458,16 @@
             "Name": "Tools & Weapons Bench Small Clamp Upgrade",
             "Tree": "Tools/Weap.",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Tool Bench Small Clamp Upgrade"
+            ],
             "Dependencies": [
                 "Cutting Tool",
-                "Building Tool",
-                "Pipe Tool"
+                "Pipe Tool",
+                "Building Tool"
+            ],
+            "Children": [
+                "Socket Tool"
             ],
             "ResearchCosts": {}
         },
@@ -360,6 +478,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Tools & Weapons Bench Small Clamp Upgrade"
+            ],
+            "Children": [
+                "Paint Tool"
             ],
             "ResearchCosts": {
                 "Cube": 10000,
@@ -373,6 +494,11 @@
             "Recipes": [],
             "Dependencies": [
                 "Socket Tool"
+            ],
+            "Children": [
+                "Brown 1",
+                "Yellow 1",
+                "Green 1"
             ],
             "ResearchCosts": {
                 "Cube": 7500,
@@ -388,6 +514,9 @@
             "Dependencies": [
                 "Paint Tool"
             ],
+            "Children": [
+                "Red 1"
+            ],
             "ResearchCosts": {
                 "Cube": 4000,
                 "Power": 2000,
@@ -402,6 +531,9 @@
             "Dependencies": [
                 "Paint Tool"
             ],
+            "Children": [
+                "Blue 1"
+            ],
             "ResearchCosts": {
                 "Power": 10000
             }
@@ -413,6 +545,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Paint Tool"
+            ],
+            "Children": [
+                "Gray 1"
             ],
             "ResearchCosts": {
                 "Power": 4000,
@@ -427,6 +562,12 @@
             "Dependencies": [
                 "Brown 1"
             ],
+            "Children": [
+                "Bright Reds",
+                "Bright Blues",
+                "White 1",
+                "Black 1"
+            ],
             "ResearchCosts": {
                 "Cube": 20000
             }
@@ -439,6 +580,12 @@
             "Dependencies": [
                 "Yellow 1"
             ],
+            "Children": [
+                "Bright Reds",
+                "Bright Blues",
+                "White 1",
+                "Black 1"
+            ],
             "ResearchCosts": {
                 "Shield": 10000
             }
@@ -450,6 +597,12 @@
             "Recipes": [],
             "Dependencies": [
                 "Green 1"
+            ],
+            "Children": [
+                "Bright Reds",
+                "Bright Blues",
+                "White 1",
+                "Black 1"
             ],
             "ResearchCosts": {
                 "Cube": 2500,
@@ -468,6 +621,7 @@
                 "Blue 1",
                 "Gray 1"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 25000,
                 "Gear": 25000
@@ -483,6 +637,7 @@
                 "Blue 1",
                 "Gray 1"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Power": 10000,
                 "Shield": 30000
@@ -498,6 +653,7 @@
                 "Blue 1",
                 "Gray 1"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 10000,
                 "Power": 10000,
@@ -515,6 +671,7 @@
                 "Blue 1",
                 "Gray 1"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 10000,
                 "Power": 10000,
@@ -530,6 +687,9 @@
             "Dependencies": [
                 "Infantry Basics"
             ],
+            "Children": [
+                "Remote Explosives"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -539,6 +699,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Infantry Basics"
+            ],
+            "Children": [
+                "Repeater Pistol"
             ],
             "ResearchCosts": {}
         },
@@ -550,6 +713,9 @@
             "Dependencies": [
                 "Long Rifle"
             ],
+            "Children": [
+                "Revolver"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -560,15 +726,24 @@
             "Dependencies": [
                 "Repeater Pistol"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
             "Name": "Tools & Weapons Bench Rifle Clamp Upgrade",
             "Tree": "Tools/Weap.",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Tool Bench Rifle Clamp Upgrade"
+            ],
             "Dependencies": [
                 "Remote Explosives"
+            ],
+            "Children": [
+                "Plasma Rifle",
+                "Battle Rifle",
+                "Bolter",
+                "Grenade Launcher"
             ],
             "ResearchCosts": {}
         },
@@ -578,8 +753,10 @@
             "IsOwned": false,
             "Recipes": [],
             "Dependencies": [
-                "Shotgun",
-                "Long Rifle"
+                "Shotgun"
+            ],
+            "Children": [
+                "Tools & Weapons Bench Rifle Clamp Upgrade"
             ],
             "ResearchCosts": {}
         },
@@ -590,6 +767,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Tools & Weapons Bench Rifle Clamp Upgrade"
+            ],
+            "Children": [
+                "Laser Rifle"
             ],
             "ResearchCosts": {
                 "Cube": 20000,
@@ -605,6 +785,9 @@
             "Dependencies": [
                 "Tools & Weapons Bench Rifle Clamp Upgrade"
             ],
+            "Children": [
+                "Laser Rifle"
+            ],
             "ResearchCosts": {
                 "Cube": 20000,
                 "Shield": 35000,
@@ -619,6 +802,9 @@
             "Dependencies": [
                 "Tools & Weapons Bench Rifle Clamp Upgrade"
             ],
+            "Children": [
+                "Rail Rifle"
+            ],
             "ResearchCosts": {
                 "Cube": 20000,
                 "Shield": 45000
@@ -631,6 +817,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Tools & Weapons Bench Rifle Clamp Upgrade"
+            ],
+            "Children": [
+                "Rocket Launcher"
             ],
             "ResearchCosts": {
                 "Cube": 25000,
@@ -646,6 +835,7 @@
             "Dependencies": [
                 "Grenade Launcher"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 50000,
                 "Shield": 75000,
@@ -660,6 +850,7 @@
             "Dependencies": [
                 "Bolter"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 40000,
                 "Shield": 60000
@@ -673,6 +864,10 @@
             "Dependencies": [
                 "Plasma Rifle",
                 "Battle Rifle"
+            ],
+            "Children": [
+                "Gauss Rifle",
+                "Antigel Rifle"
             ],
             "ResearchCosts": {
                 "Cube": 20000,
@@ -688,6 +883,7 @@
             "Dependencies": [
                 "Laser Rifle"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 80000,
                 "Shield": 20000
@@ -701,6 +897,7 @@
             "Dependencies": [
                 "Laser Rifle"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 60000,
                 "Shield": 60000
@@ -714,6 +911,11 @@
                 "Basic Crafting Bench"
             ],
             "Dependencies": [],
+            "Children": [
+                "Windows",
+                "Basic",
+                "Extension and Adapter Modules"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -724,15 +926,28 @@
             "Dependencies": [
                 "Basic Crafting Bench"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
             "Name": "Basic",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Basic",
+                "Basic 1 Hardpoint",
+                "L-Shape 1 Hardpoint",
+                "L-Shape 2 Hardpoint",
+                "L-Shape Basic",
+                "L-Shape Basic Corner",
+                "Curved Basic",
+                "Curved Corner 2 Hardpoint"
+            ],
             "Dependencies": [
                 "Basic Crafting Bench"
+            ],
+            "Children": [
+                "Cargo Box"
             ],
             "ResearchCosts": {}
         },
@@ -740,19 +955,48 @@
             "Name": "Extension and Adapter Modules",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Extention Wing 5 Hardpoint (1 Connection)",
+                "Extention Hatch",
+                "Curved L-Shape Adapter",
+                "Bottleneck 4",
+                "Bottleneck 4 Curved",
+                "Bottleneck 2",
+                "Bottleneck 1",
+                "Inner Corner",
+                "Extention 5 Hardpoint (1 Connection)",
+                "Extention 3 Hardpoint (3 Connection)",
+                "Extention 2 Hardpoint (3 Connection)",
+                "Extention (3 Connection)",
+                "Extention 4 Hardpoint (2 Connection)"
+            ],
             "Dependencies": [
                 "Basic Crafting Bench"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
             "Name": "Cargo Box",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Modular Ore Cargo Crate",
+                "L-Shape 1 Ore Crate",
+                "Basic 1 Ore Crate (Corner)",
+                "Curved 1 Ore Crate",
+                "Block of 4 Ore Crates",
+                "Extention Corner 3 Ore Crate"
+            ],
             "Dependencies": [
                 "Basic"
+            ],
+            "Children": [
+                "Extra Plates Bundle",
+                "Control Tables, Screens, Small Devices",
+                "Tier 1 Thrusters",
+                "Tier 1 Generators",
+                "Fuel Rods"
             ],
             "ResearchCosts": {}
         },
@@ -764,6 +1008,9 @@
             "Dependencies": [
                 "Cargo Box"
             ],
+            "Children": [
+                "Extra Beams Bundle"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -774,15 +1021,25 @@
             "Dependencies": [
                 "Extra Plates Bundle"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
             "Name": "Control Tables, Screens, Small Devices",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Pilot Chair Stand",
+                "Resource Bridge",
+                "Main Flight Computer",
+                "Pilot Chair",
+                "Flight Control Unit Basic"
+            ],
             "Dependencies": [
                 "Cargo Box"
+            ],
+            "Children": [
+                "Hinges & Hatches"
             ],
             "ResearchCosts": {}
         },
@@ -790,19 +1047,37 @@
             "Name": "Hinges & Hatches",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Hinge A 48x144 cm",
+                "Hinge (C-profile) 48x144x36 cm",
+                "Hinge (L-profile) 24x144x36 cm",
+                "Slider Basic A 48x144 cm",
+                "Hinge B 48x144 cm"
+            ],
             "Dependencies": [
                 "Control Tables, Screens, Small Devices"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
             "Name": "Tier 1 Thrusters",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Triangle Thruster Nozzle Tier 1",
+                "Box Thruster Nozzle Tier 1",
+                "Box Thruster Combustion Chamber",
+                "Triangle Thruster Base Tier 1",
+                "T1 Thruster Box",
+                "T1 Thruster Triangle",
+                "Box Thruster Body Tier 1"
+            ],
             "Dependencies": [
                 "Cargo Box"
+            ],
+            "Children": [
+                "Cockpit Modules"
             ],
             "ResearchCosts": {}
         },
@@ -810,9 +1085,17 @@
             "Name": "Tier 1 Generators",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Small Cooling Cell",
+                "Small Rechargeable Battery",
+                "Generator Fuel Chamber Tier 1"
+            ],
             "Dependencies": [
                 "Cargo Box"
+            ],
+            "Children": [
+                "Radiators",
+                "Cockpit Modules"
             ],
             "ResearchCosts": {}
         },
@@ -820,9 +1103,16 @@
             "Name": "Fuel Rods",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Tier 1 Generator Fuel Rod",
+                "Small Fuel Rod Rack"
+            ],
             "Dependencies": [
                 "Cargo Box"
+            ],
+            "Children": [
+                "Small Propellant Tank",
+                "Cockpit Modules"
             ],
             "ResearchCosts": {}
         },
@@ -830,31 +1120,51 @@
             "Name": "Small Propellant Tank",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Small Hydrogen Propellant Tank"
+            ],
             "Dependencies": [
                 "Fuel Rods"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
             "Name": "Radiators",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Radiator Base",
+                "Radiator Extension"
+            ],
             "Dependencies": [
                 "Tier 1 Generators"
             ],
+            "Children": [],
             "ResearchCosts": {}
         },
         {
             "Name": "Cockpit Modules",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Top Cockpit Exposed 1x2 Wide",
+                "Cockpit 3 Medium Exposed",
+                "Top Cockpit Exposed 1x2 Long",
+                "Cockpit 3 Small",
+                "Cockpit 2 Small Exposed",
+                "Cockpit 2 Small Exposed (T1 Laborer)"
+            ],
             "Dependencies": [
                 "Tier 1 Generators",
                 "Tier 1 Thrusters",
                 "Fuel Rods"
+            ],
+            "Children": [
+                "Tripod Autocannon",
+                "Basic Yolol Chip",
+                "Ship Diagnostic Scanner",
+                "Material Point Scanner"
             ],
             "ResearchCosts": {}
         },
@@ -866,15 +1176,24 @@
             "Dependencies": [
                 "Cockpit Modules"
             ],
+            "Children": [
+                "Yolol Rack Chip Reader",
+                "Navigation Receivers & Transponders"
+            ],
             "ResearchCosts": {}
         },
         {
             "Name": "Ship Diagnostic Scanner",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Ship Diagnostic Scanner"
+            ],
             "Dependencies": [
                 "Cockpit Modules"
+            ],
+            "Children": [
+                "Crafting Bench Meter Upgrade"
             ],
             "ResearchCosts": {}
         },
@@ -882,9 +1201,20 @@
             "Name": "Material Point Scanner",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Turret Turntable",
+                "Turret Cradle Advanced",
+                "Small Turntable Mount 2",
+                "Material Point Scanner",
+                "Fixed Weapon Mount 2",
+                "Material Point Scanner Fixed Mount"
+            ],
             "Dependencies": [
                 "Cockpit Modules"
+            ],
+            "Children": [
+                "Mining Laser",
+                "Ore Collector"
             ],
             "ResearchCosts": {}
         },
@@ -892,9 +1222,16 @@
             "Name": "Tripod Autocannon",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Tripod",
+                "Tripod Autocannon",
+                "Tripod Autocannon Magazine"
+            ],
             "Dependencies": [
                 "Cockpit Modules"
+            ],
+            "Children": [
+                "Mounted Autocannon"
             ],
             "ResearchCosts": {}
         },
@@ -905,6 +1242,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Tripod Autocannon"
+            ],
+            "Children": [
+                "Weapons and Tools Bench Large Clamp Upgrade"
             ],
             "ResearchCosts": {
                 "Cube": 30000,
@@ -919,6 +1259,10 @@
             "Recipes": [],
             "Dependencies": [
                 "Mounted Autocannon"
+            ],
+            "Children": [
+                "Mounted Plasma Cannon",
+                "Mounted Laser Cannon"
             ],
             "ResearchCosts": {
                 "Cube": 5000,
@@ -935,6 +1279,9 @@
             "Dependencies": [
                 "Weapons and Tools Bench Large Clamp Upgrade"
             ],
+            "Children": [
+                "Missles"
+            ],
             "ResearchCosts": {
                 "Cube": 80000,
                 "Shield": 50000
@@ -947,6 +1294,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Weapons and Tools Bench Large Clamp Upgrade"
+            ],
+            "Children": [
+                "Torpedoes"
             ],
             "ResearchCosts": {
                 "Power": 80000,
@@ -962,6 +1312,9 @@
             "Dependencies": [
                 "Mounted Plasma Cannon"
             ],
+            "Children": [
+                "Mounted Railgun"
+            ],
             "ResearchCosts": {
                 "Cube": 100000,
                 "Shield": 100000
@@ -974,6 +1327,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Mounted Laser Cannon"
+            ],
+            "Children": [
+                "Mounted Railgun"
             ],
             "ResearchCosts": {
                 "Power": 100000,
@@ -990,6 +1346,7 @@
                 "Missles",
                 "Torpedoes"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 100000,
                 "Power": 100000,
@@ -1005,15 +1362,24 @@
             "Dependencies": [
                 "Material Point Scanner"
             ],
+            "Children": [
+                "Crafting Bench Cables Upgrade"
+            ],
             "ResearchCosts": {}
         },
         {
             "Name": "Mining Laser",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Mining Laser",
+                "Mining Laser Fixed Mount"
+            ],
             "Dependencies": [
                 "Material Point Scanner"
+            ],
+            "Children": [
+                "Crafting Bench Cables Upgrade"
             ],
             "ResearchCosts": {}
         },
@@ -1025,6 +1391,10 @@
             "Dependencies": [
                 "Ore Collector",
                 "Mining Laser"
+            ],
+            "Children": [
+                "Rangefinder",
+                "Laser Designator"
             ],
             "ResearchCosts": {
                 "Cube": 2000,
@@ -1041,6 +1411,9 @@
             "Dependencies": [
                 "Crafting Bench Cables Upgrade"
             ],
+            "Children": [
+                "Tractor Beam"
+            ],
             "ResearchCosts": {
                 "Cube": 8000,
                 "Power": 5000
@@ -1053,6 +1426,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Crafting Bench Cables Upgrade"
+            ],
+            "Children": [
+                "Tractor Beam"
             ],
             "ResearchCosts": {
                 "Cube": 10000,
@@ -1069,6 +1445,10 @@
                 "Rangefinder",
                 "Laser Designator"
             ],
+            "Children": [
+                "Cargo Lock Beam",
+                "Cargo Lock Frame"
+            ],
             "ResearchCosts": {
                 "Cube": 6000,
                 "Power": 12000,
@@ -1083,6 +1463,7 @@
             "Dependencies": [
                 "Tractor Beam"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 8000,
                 "Power": 5000,
@@ -1097,6 +1478,7 @@
             "Dependencies": [
                 "Tractor Beam"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 6000,
                 "Power": 8000,
@@ -1107,9 +1489,15 @@
             "Name": "Crafting Bench Meter Upgrade",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Basic Crafting Bench Meter Upgrade"
+            ],
             "Dependencies": [
                 "Ship Diagnostic Scanner"
+            ],
+            "Children": [
+                "Tier 2 Generator",
+                "Tier 2 Thrusters"
             ],
             "ResearchCosts": {
                 "Cube": 3000,
@@ -1121,9 +1509,16 @@
             "Name": "Tier 2 Generator",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Generator Unit Tier 2",
+                "Tier 2 Generator Fuel Rod",
+                "Generator Fuel Chamber Tier 2"
+            ],
             "Dependencies": [
                 "Crafting Bench Meter Upgrade"
+            ],
+            "Children": [
+                "Advanced Flight Control Unit"
             ],
             "ResearchCosts": {
                 "Cube": 12000,
@@ -1135,9 +1530,20 @@
             "Name": "Tier 2 Thrusters",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Triangle Thruster Nozzle Tier 2",
+                "Triangle Thruster Base Tier 2",
+                "Thruster Propellant Converter Tier 2",
+                "Thruster Electricity Converter Tier 2",
+                "Maneuver Thruster Tier 2",
+                "Box Thruster Body Tier 2",
+                "Box Thruster Nozzle Tier 2"
+            ],
             "Dependencies": [
                 "Crafting Bench Meter Upgrade"
+            ],
+            "Children": [
+                "Medium Propellant Tank"
             ],
             "ResearchCosts": {
                 "Cube": 10000,
@@ -1153,6 +1559,9 @@
             "Dependencies": [
                 "Tier 2 Generator"
             ],
+            "Children": [
+                "Fast Travel Core"
+            ],
             "ResearchCosts": {
                 "Cube": 6000,
                 "Power": 8000,
@@ -1163,9 +1572,14 @@
             "Name": "Medium Propellant Tank",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Medium Hydrogen Propellant Tank"
+            ],
             "Dependencies": [
                 "Tier 2 Thrusters"
+            ],
+            "Children": [
+                "Fast Travel Core"
             ],
             "ResearchCosts": {
                 "Cube": 20000,
@@ -1181,6 +1595,9 @@
                 "Advanced Flight Control Unit",
                 "Medium Propellant Tank"
             ],
+            "Children": [
+                "Crafting Bench Monitor Upgrade"
+            ],
             "ResearchCosts": {
                 "Cube": 5000,
                 "Power": 5000,
@@ -1194,6 +1611,11 @@
             "Recipes": [],
             "Dependencies": [
                 "Fast Travel Core"
+            ],
+            "Children": [
+                "Tier 3 Thrusters",
+                "Tier 3 Generator",
+                "Premium Flight Control Unit"
             ],
             "ResearchCosts": {
                 "Cube": 30000,
@@ -1209,6 +1631,7 @@
             "Dependencies": [
                 "Crafting Bench Monitor Upgrade"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 10000,
                 "Power": 20000,
@@ -1223,6 +1646,7 @@
             "Dependencies": [
                 "Crafting Bench Monitor Upgrade"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 25000,
                 "Power": 35000,
@@ -1236,6 +1660,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Crafting Bench Monitor Upgrade"
+            ],
+            "Children": [
+                "Large Propellant Tank"
             ],
             "ResearchCosts": {
                 "Cube": 20000,
@@ -1251,6 +1678,9 @@
             "Dependencies": [
                 "Tier 3 Thrusters"
             ],
+            "Children": [
+                "Plasma Thruster"
+            ],
             "ResearchCosts": {
                 "Cube": 20000,
                 "Power": 20000,
@@ -1265,6 +1695,7 @@
             "Dependencies": [
                 "Large Propellant Tank"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 30000,
                 "Power": 30000,
@@ -1279,15 +1710,25 @@
             "Dependencies": [
                 "Basic Yolol Chip"
             ],
+            "Children": [
+                "Crafting Bench Soldering Iron Upgrade"
+            ],
             "ResearchCosts": {}
         },
         {
             "Name": "Navigation Receivers & Transponders",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Ship Transponder",
+                "Navigation Receiver",
+                "Small Navigation Receiver"
+            ],
             "Dependencies": [
                 "Basic Yolol Chip"
+            ],
+            "Children": [
+                "Audio Signal Device"
             ],
             "ResearchCosts": {}
         },
@@ -1299,6 +1740,7 @@
             "Dependencies": [
                 "Navigation Receivers & Transponders"
             ],
+            "Children": [],
             "ResearchCosts": {
                 "Cube": 1000,
                 "Power": 2000
@@ -1308,10 +1750,14 @@
             "Name": "Crafting Bench Soldering Iron Upgrade",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Basic Crafting Bench Soldering Iron Upgrade"
+            ],
             "Dependencies": [
-                "Yolol Rack Chip Reader",
-                "Navigation Receivers & Transponders"
+                "Yolol Rack Chip Reader"
+            ],
+            "Children": [
+                "Advanced Yolol Chip"
             ],
             "ResearchCosts": {}
         },
@@ -1323,6 +1769,10 @@
             "Dependencies": [
                 "Crafting Bench Soldering Iron Upgrade"
             ],
+            "Children": [
+                "Network Relay",
+                "Yolol Memory Chip"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -1333,6 +1783,9 @@
             "Dependencies": [
                 "Advanced Yolol Chip"
             ],
+            "Children": [
+                "Professional Yolol Chip"
+            ],
             "ResearchCosts": {}
         },
         {
@@ -1342,6 +1795,9 @@
             "Recipes": [],
             "Dependencies": [
                 "Advanced Yolol Chip"
+            ],
+            "Children": [
+                "Professional Yolol Chip"
             ],
             "ResearchCosts": {}
         },
@@ -1354,16 +1810,26 @@
                 "Yolol Memory Chip",
                 "Network Relay"
             ],
+            "Children": [
+                "Reconstruction Machine"
+            ],
             "ResearchCosts": {}
         },
         {
             "Name": "Reconstruction Machine",
             "Tree": "Basic",
             "IsOwned": false,
-            "Recipes": [],
+            "Recipes": [
+                "Reconstruction Machine Fabricator Module",
+                "Reconstruction Machine Cradle Module",
+                "Reconstruction Machine Generator Module",
+                "Reconstruction Machine Terminal Module",
+                "Endoskeleton Replacement Kit"
+            ],
             "Dependencies": [
                 "Professional Yolol Chip"
             ],
+            "Children": [],
             "ResearchCosts": {}
         }
     ]

--- a/data.json
+++ b/data.json
@@ -1918,6 +1918,40 @@
             "Favourite": 0,
             "Hide": 0,
             "VendorPrice": 0.0
+        },
+        {
+            "Name": "Grenade",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Ice": 53.4,
+                "Vokarium": 178.0,
+                "Nhurgite": 480.6,
+                "Bastium": 0.09
+            },
+            "Research": {
+                "Shield": 42
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
+        },
+        {
+            "Name": "Grenade Launcher",
+            "CraftingTime": 0.0,
+            "Materials": {
+                "Ajatite": 639.0,
+                "Kutonium": 1317.0,
+                "Vokarium": 676.0,
+                "Charodium": 1127.0
+            },
+            "Research": {
+                "Cube": 2,
+                "Shield": 6,
+                "Gear": 6
+            },
+            "Favourite": 0,
+            "Hide": 0,
+            "VendorPrice": 0.0
         }
     ]
 }

--- a/data.json
+++ b/data.json
@@ -1424,7 +1424,7 @@
             "VendorPrice": 0.0
         },
         {
-            "Name": "Advanced Crafting Bench Saw Upgrade",
+            "Name": "Advanced Crafting Bench Metal Saw Upgrade",
             "CraftingTime": 0.0,
             "Materials": {
                 "Vokarium": 2736.75,

--- a/index.html
+++ b/index.html
@@ -225,8 +225,8 @@
                 //#endregion
             });
 
-                // Handle calculation request.
-                function RunCalculation(hiddenMats) {
+            // Handle calculation request.
+            function RunCalculation(hiddenMats) {
                     //#region Variable initialization.
                     var useableObjs = [];
                     var relevantMaterials = [];


### PR DESCRIPTION
Added grenade launcher and grenades to the recipe data, fixed incorrect Hinge B costs, and the biggest thing here is:

I've added the data for ALL research nodes in the game. Note, however, they only have recipes if those recipes also exist in the current SRC dataset. The research nodes have the following object format: 
```
{
        "Name": "NodeName",
        "Tree": "TreeName",
        "IsOwned": false,
        "Recipes": [
            /* Recipes the node unlocks */
        ],
        "Dependencies": [
            /* The nodes directly above this node */
        ],
        "Children": [
            /* The nodes directly below this node */
        ],
        "ResearchCosts": {
            "Cube": 0,
            "Power": 0,
            "Shield": 0,
            "Gear": 0
            /* Only contains entries for extant costs */
        }
}
```